### PR TITLE
fix:修复不兼容所有Image类型组件的渲染

### DIFF
--- a/harmony/color_matrix_image_filters/src/main/cpp/ColorMatrixImageFiltersComponentInstance.cpp
+++ b/harmony/color_matrix_image_filters/src/main/cpp/ColorMatrixImageFiltersComponentInstance.cpp
@@ -50,21 +50,31 @@ namespace rnoh {
         }
     }
 
-    void  ColorMatrixImageFiltersComponentInstance::finalizeUpdates(){
-        for(auto child : getChildren()){
-            if (child->getComponentName() == "Image") {
-               auto imageComponentInstance = std::dynamic_pointer_cast<rnoh::ImageComponentInstance>(child);
-               std::vector<ArkUI_NumberValue> value = {};
-               for(auto matrix : this->m_matrix) {
-                  value.push_back({.f32 = static_cast<float>(matrix)});  
-               }
-               ArkUI_AttributeItem item = {value.data(),static_cast<int32_t>(value.size())};
-               NativeNodeApi::getInstance()->setAttribute(imageComponentInstance->getLocalRootArkUINode().getArkUINodeHandle(), NODE_IMAGE_COLOR_FILTER,&item);
-           }
+void ColorMatrixImageFiltersComponentInstance::finalizeUpdates() {
+    std::vector<ComponentInstance::Shared> childNodes = findImageNode(getChildren());
+    for (auto childNode : childNodes) {
+        std::vector<ArkUI_NumberValue> value = {};
+        for (auto matrix : this->m_matrix) {
+            value.push_back({.f32 = static_cast<float>(matrix)});
         }
+        ArkUI_AttributeItem item = {value.data(), static_cast<int32_t>(value.size())};
+        NativeNodeApi::getInstance()->setAttribute(childNode->getLocalRootArkUINode().getArkUINodeHandle(),
+                                                   NODE_IMAGE_COLOR_FILTER, &item);
     }
+}
 
-
- 
+std::vector<ComponentInstance::Shared>
+ColorMatrixImageFiltersComponentInstance::findImageNode(const std::vector<ComponentInstance::Shared> &childNodes) {
+    std::vector<ComponentInstance::Shared> result;
+    for (const auto &childNode : childNodes) {
+        if (OH_ArkUI_NodeUtils_GetNodeType(childNode->getLocalRootArkUINode().getArkUINodeHandle()) ==
+            ARKUI_NODE_IMAGE) {
+            result.push_back(childNode);
+        }
+        auto nodeResults = findImageNode(childNode->getChildren());
+        result.insert(result.end(), nodeResults.begin(), nodeResults.end());
+    }
+    return result;
+}
 
 } // namespace rnoh/

--- a/harmony/color_matrix_image_filters/src/main/cpp/ColorMatrixImageFiltersComponentInstance.h
+++ b/harmony/color_matrix_image_filters/src/main/cpp/ColorMatrixImageFiltersComponentInstance.h
@@ -49,5 +49,7 @@ namespace rnoh {
 
         void finalizeUpdates() override;
     
+        std::vector<ComponentInstance::Shared> findImageNode(const std::vector<ComponentInstance::Shared>& childNodes);
+    
      };
 } // namespace rnoh


### PR DESCRIPTION
# Summary
- fix:修复不兼容所有Image类型组件的渲染
- Close: #7 


## Test Plan

- 1、验证测试用例是否全部兼容fastimage
- 2、已验证ok

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)